### PR TITLE
Allows single point of configuration:  DO NOT MERGE

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Eslint configs for Rhinogram",
   "main": "react.js",
   "author": "Rhinogram, LLC",
+  "bin": {
+    "eslint": "./node_modules/eslint/bin/eslint.js"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
   "license": "MIT",
   "dependencies": {
     "babel-eslint": "8.2.3",


### PR DESCRIPTION
Allows a single config of our eslint config without having to match all the versions/dependencies across all our projects.

This will allows us to remove eslint dependencies completely from all projects that use this module.
There are additional PRs required for RhinoAPI and Rhinofront for this to work.

https://github.com/eslint/eslint/issues/3458  


See this issue - if you scroll to the bottom you can see how its fixed.

