### PR TITLE
allow es6 arrow functions and do not enforce spread operator

### DIFF
--- a/node.js
+++ b/node.js
@@ -7,12 +7,13 @@ module.exports = {
   plugins: ["babel"],
   rules: {
     "no-unused-vars": 1,
-    "arrow-body-style": 1,
-    "arrow-parens": 1,
+    "arrow-body-style": [2, "as-needed"],
+    "arrow-parens": 0,
     "import/prefer-default-export": 0,
     "max-len": [1, { code: 170 }],
     "no-use-before-define": 0,
     "no-param-reassign": 0,
+    "prefer-spread": 0,
     "import/no-cycle": 0
   }
 };


### PR DESCRIPTION
Currently, the config forces you to write one line returns as:
```bash
const bar = [{ name: 'bob' }];
const foo = bar.find((i) => { return i.name === 'bob'; });
```
The arrow rules update will allow a simpler one line return:
```bash
const bar = [{ name: 'bob' }];
const foo = bar.find((i) => i.name === 'bob');
```

In addition to the arrow rules, this PR will prevent error-ing when you do not want spread operators. The `rhinocloud-sdk` is ES5, as it is a lightweight module. There is one particular instance where I need to use `.apply()`, however the eslint rules will force the use of the `...` operator in addition to the `.apply()`, which actually breaks the functionality somehow. 