### PR TITLE
making 'babel-eslint' the default parser to enable plugin usage.

### DIFF
--- a/node.js
+++ b/node.js
@@ -5,6 +5,7 @@ module.exports = {
     jest: true,
   },
   extends: 'airbnb-base',
+  parser: 'babel-eslint',
   plugins: ['babel'],
   rules: {
     'no-unused-vars': 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-rhinogram",
-  "version": "0.0.18",
+  "version": "0.0.20",
   "description": "Eslint configs for Rhinogram",
   "main": "react.js",
   "author": "Rhinogram, LLC",


### PR DESCRIPTION
This should properly enable babel plugin usage on node services. Currently, even though the babel plugins do their job transpiling properly, the lint process will fail due to eslint default parser not recognizing new syntax.

**NOTE: ** Jumped 2 versions in package.json because we seemed to be 1 version behind actual github releases.