### PR TITLE
Update react/no-did-update-set-state rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -63,6 +63,7 @@ module.exports = {
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
     }],
+    "react/no-did-update-set-state": 0,
 
     /////////
 


### PR DESCRIPTION
Removed rule preventing setState in componentDidUpdate since we no longer use constructors or will mount. 