### PR TITLE
Disables react/state-in-constructor, react/jsx-props-no-spreading & import/no-cycle

### DIFF
--- a/react.js
+++ b/react.js
@@ -68,6 +68,7 @@ module.exports = {
     "react/jsx-props-no-spreading": 0,
     "import/no-cycle": 0,
     "react/jsx-fragments": 0,
+    "react/jsx-curly-newline": 0,
 
     /////////
 

--- a/react.js
+++ b/react.js
@@ -66,7 +66,7 @@ module.exports = {
     "react/no-did-update-set-state": 0,
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
-    "import/no-cycle": 0
+    "import/no-cycle": 0,
     "react/jsx-fragments": 0,
 
     /////////

--- a/react.js
+++ b/react.js
@@ -50,7 +50,7 @@ module.exports = {
     "no-unused-vars": 1,
     "react/no-unused-prop-types": 1,
     "arrow-body-style": 1,
-    "arrow-parens": 1,
+    "arrow-parens": 0,
     "import/prefer-default-export": 1,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -66,7 +66,8 @@ module.exports = {
     "react/no-did-update-set-state": 0,
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
-    "import/no-cycle": 0,
+    "import/no-cycle": 0
+    "react/jsx-fragments": 0,
 
     /////////
 

--- a/react.js
+++ b/react.js
@@ -66,6 +66,7 @@ module.exports = {
     "react/no-did-update-set-state": 0,
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
+    "import/no-cycle": 0,
 
     /////////
 

--- a/react.js
+++ b/react.js
@@ -63,12 +63,12 @@ module.exports = {
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
     }],
-    "react/no-did-update-set-state": 0,
-    "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
     "import/no-cycle": 0,
 
-    /////////
+    // rules to revisit in future airbnb updates
+    "react/no-did-update-set-state": 0,
+    "react/state-in-constructor": 0,
 
     // Old rules to investigate removing
     "class-methods-use-this": 0,

--- a/react.js
+++ b/react.js
@@ -65,6 +65,7 @@ module.exports = {
     }],
     "react/no-did-update-set-state": 0,
     "react/state-in-constructor": 0,
+    "react/jsx-props-no-spreading": 0,
 
     /////////
 

--- a/react.js
+++ b/react.js
@@ -50,7 +50,7 @@ module.exports = {
     "no-unused-vars": 1,
     "react/no-unused-prop-types": 1,
     "arrow-body-style": 1,
-    "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
+    "arrow-parens": 1,
     "import/prefer-default-export": 1,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -67,8 +67,6 @@ module.exports = {
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
     "import/no-cycle": 0,
-    "react/jsx-fragments": 0,
-    "react/jsx-curly-newline": 0,
 
     /////////
 

--- a/react.js
+++ b/react.js
@@ -50,7 +50,7 @@ module.exports = {
     "no-unused-vars": 1,
     "react/no-unused-prop-types": 1,
     "arrow-body-style": 1,
-    "arrow-parens": 0,
+    "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
     "import/prefer-default-export": 1,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",

--- a/react.js
+++ b/react.js
@@ -64,6 +64,7 @@ module.exports = {
       ignoreTemplateLiterals: true,
     }],
     "react/no-did-update-set-state": 0,
+    "react/state-in-constructor": 0,
 
     /////////
 


### PR DESCRIPTION
 Disables following rules

- `react/state-in-constructor`, 
- `react/jsx-props-no-spreading` 
- `import/no-cycle` 
- `react/jsx-fragments`
- `arrow-parens`